### PR TITLE
telethon_bridge: Implement missing functions

### DIFF
--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -157,7 +157,7 @@ class TelethonBridge(MTProtoBridgeBase):
             raise RuntimeError(f'Can\'t get full chat by {group}')
 
         self.group_call = self.full_chat.call
-        self.join_as = self.full_chat.groupcall_default_join_as
+       
 
         return self.group_call
 

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -167,7 +167,7 @@ class TelethonBridge(MTProtoBridgeBase):
         self.client.add_event_handler(self._process_update, Raw)
 
     async def resolve_and_set_join_as(self, join_as):
-        if self.join_as is None:
+        if join_as is None:
             self.join_as = await self.get_and_set_self_peer()
         else:
             self.join_as = join_as

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -167,7 +167,10 @@ class TelethonBridge(MTProtoBridgeBase):
         self.client.add_event_handler(self._process_update, Raw)
 
     async def resolve_and_set_join_as(self, join_as):
-        self.join_as = join_as
+        if self.join_as is None:
+            self.join_as = await self.get_and_set_self_peer()
+        else:
+            self.join_as = join_as
 
     async def send_speaking_group_call_action(self):
         await self.client(functions.messages.SetTypingRequest(peer=self.chat_peer, action=SpeakingInGroupCallAction()))

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -32,7 +32,9 @@ from telethon.tl.types import (
     SpeakingInGroupCallAction,
     UpdateGroupCall,
     UpdateGroupCallConnection,
-    UpdateGroupCallParticipants, InputPeerChat, InputPeerChannel,
+    UpdateGroupCallParticipants,
+    InputPeerChat,
+    InputPeerChannel,
 )
 
 from pytgcalls.mtproto import MTProtoBridgeBase
@@ -157,7 +159,6 @@ class TelethonBridge(MTProtoBridgeBase):
             raise RuntimeError(f'Can\'t get full chat by {group}')
 
         self.group_call = self.full_chat.call
-       
 
         return self.group_call
 

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -25,7 +25,7 @@ from telethon.errors import (
     GroupcallSsrcDuplicateMuchError as TelethonGroupcallSsrcDuplicateMuchError,
 )
 from telethon.events import Raw, StopPropagation
-from telethon.tl import functions, TLObject
+from telethon.tl import functions
 from telethon.tl.types import (
     DataJSON,
     GroupCallDiscarded as TelethonGroupCallDiscarded,

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -170,6 +170,8 @@ class TelethonBridge(MTProtoBridgeBase):
     async def resolve_and_set_join_as(self, join_as):
         if join_as is None:
             self.join_as = self.full_chat.groupcall_default_join_as
+            if self.join_as is None:
+                self.join_as = await self.get_and_set_self_peer()
         else:
             self.join_as = join_as
 

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -157,6 +157,7 @@ class TelethonBridge(MTProtoBridgeBase):
             raise RuntimeError(f'Can\'t get full chat by {group}')
 
         self.group_call = self.full_chat.call
+        self.join_as = self.full_chat.groupcall_default_join_as
 
         return self.group_call
 

--- a/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
+++ b/pytgcalls/pytgcalls/mtproto/telethon_bridge.py
@@ -169,7 +169,7 @@ class TelethonBridge(MTProtoBridgeBase):
 
     async def resolve_and_set_join_as(self, join_as):
         if join_as is None:
-            self.join_as = await self.get_and_set_self_peer()
+            self.join_as = self.full_chat.groupcall_default_join_as
         else:
             self.join_as = join_as
 


### PR DESCRIPTION
Replaced any entity getter with a less request-hungry one (get_entity -> get_input_entity). Tell me if somehow you need the full entity instead of the Input object (InputPeer, InputUser).

Also removed get_input_entity where not needed. Telethon auto casts username's, ids, Chat, Channel objects to the required InputPeer when making an raw request