### PR TITLE
Completely reworked system of managing instances (smart pointers) and working with memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(tgcalls
     LANGUAGES C CXX
     DESCRIPTION "Python binding for tgcalls"
     HOMEPAGE_URL "https://github.com/MarshalX/tgcalls"
-    VERSION "2.0.0.1"
+    VERSION "2.0.0.2"
 )
 
 get_filename_component(third_party_loc "tgcalls/third_party" REALPATH)

--- a/pytgcalls/pytgcalls/__init__.py
+++ b/pytgcalls/pytgcalls/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
     'GroupCallDevice',
     'GroupCallRaw',
 ]
-__version__ = '2.0.0.dev2'
+__version__ = '2.0.0.dev3'
 __pdoc__ = {
     # files
     'utils': False,

--- a/pytgcalls/pytgcalls/implementation/group_call_device.py
+++ b/pytgcalls/pytgcalls/implementation/group_call_device.py
@@ -37,8 +37,6 @@ class GroupCallDevice(GroupCallNative):
         self.__is_playout_paused = False
         self.__is_recording_paused = False
 
-        self.__raw_audio_device_descriptor = None
-
         self.__audio_input_device = audio_input_device or ''
         self.__audio_output_device = audio_output_device or ''
 

--- a/pytgcalls/setup.py
+++ b/pytgcalls/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     packages=packages,
-    install_requires=['tgcalls == 2.0.0.dev1'],
+    install_requires=['tgcalls == 2.0.0.dev2'],
     extras_require={
         'pyrogram': ['pyrogram >= 1.2.0'],
         'telethon': ['telethon >= 1.23.0'],

--- a/pytgcalls/test.py
+++ b/pytgcalls/test.py
@@ -457,7 +457,7 @@ async def start(client1, client2, make_out, make_inc):
 
 import logging
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 for name, logger in logging.root.manager.loggerDict.items():
     if name.startswith('pyrogram'):
@@ -474,28 +474,75 @@ async def main(client1, client2, telethon1, make_out, make_inc):
         await asyncio.sleep(1)
 
     # example hot to use another mtproto backend
-    # group_call_factory = GroupCallFactory(telethon1, GroupCallFactory.MTPROTO_CLIENT_TYPE.TELETHON)
-    group_call_factory = GroupCallFactory(client2, GroupCallFactory.MTPROTO_CLIENT_TYPE.PYROGRAM)
+    group_call_factory = GroupCallFactory(telethon1, GroupCallFactory.MTPROTO_CLIENT_TYPE.TELETHON, enable_logs_to_console=False)
+    # group_call_factory = GroupCallFactory(client2, GroupCallFactory.MTPROTO_CLIENT_TYPE.PYROGRAM, enable_logs_to_console=False, outgoing_audio_bitrate_kbit=512)
 
-    gc = group_call_factory.get_file_group_call('input.raw')
-    await gc.start('@ilya_marshal')
-    await gc.stop()
-    await gc.stop()
-    print('case 1')
-    await gc.start('@ilya_marshal')
-    await asyncio.sleep(10)
-    await gc.stop()
-    await gc.stop()
-    print('case 2')
-    await gc.start('@ilya_marshal')
-    print('case 3')
-    await gc.start('@ilya_marshal')
-    print('case 4')
-    await asyncio.sleep(10)
-    await gc.reconnect()
-    print('case 5')
+    def on_played_data(_, leng):
+        # print('on_played_data')
+        pass
 
-    print('all cases has been passed')
+    def on_recorded_data(_, data, leng):
+        # print('on_recorded_data')
+        pass
+    #
+    # try:
+    #     gcf = GroupCallFactory(client2)
+    #     gc = gcf.get_file_group_call('input.raw')
+    #     await gc.start('@ilya_marshal')
+    # except RuntimeError:
+    #     print('pass1')
+    #
+    # try:
+    #     gcf2 = GroupCallFactory(client2)
+    #     gc2 = gcf2.get_file_group_call('input.raw')
+    #     await gc2.start('@ilya_marshal')
+    # except RuntimeError:
+    #     print('pass2')
+
+    # group_call = group_call_factory.get_device_group_call()
+    group_call = group_call_factory.get_file_group_call('input.raw')
+    # group_call = group_call_factory.get_raw_group_call(on_recorded_data=on_recorded_data, on_played_data=on_played_data)
+    await group_call.start('@ilya_marshal')
+    # await asyncio.sleep(15)
+    # group_call.restart_playout()
+    # await group_call.stop()
+    # await group_call.reconnect()
+    # await group_call.start('@ilya_marshal')
+    # await asyncio.sleep(2)
+
+    # while True:
+    #     group_call_factory = GroupCallFactory(telethon1, GroupCallFactory.MTPROTO_CLIENT_TYPE.TELETHON)
+    #     # group_call_factory = GroupCallFactory(client2, GroupCallFactory.MTPROTO_CLIENT_TYPE.PYROGRAM, enable_logs_to_console=False, outgoing_audio_bitrate_kbit=512)
+    #     group_call = group_call_factory.get_raw_group_call(on_played_data=on_played_data)
+    #     # group_call = group_call_factory.get_file_group_call('input.raw')
+    #     await group_call.start('@ilya_marshal')
+    #     await asyncio.sleep(5)
+    #     # await group_call.stop()
+    #     # del group_call
+    #     await asyncio.sleep(2)
+    #     break
+
+    # gc = group_call_factory.get_file_group_call('input.raw')
+    # # gc = group_call_factory.get_device_group_call()
+    # await gc.start('@ilya_marshal')
+    # await gc.stop()
+    # await gc.stop()
+    # print('case 1')
+    # await gc.start('@ilya_marshal')
+    # await asyncio.sleep(20)
+    # await gc.set_is_mute(True)
+    # await gc.stop()
+    # await gc.stop()
+    # print('case 2')
+    # await gc.start('@ilya_marshal')
+    # print('case 3')
+    # await gc.start('@ilya_marshal')
+    # print('case 4')
+    # await asyncio.sleep(10)
+    # await gc.reconnect()
+    # print('case 5')
+    #
+    # print('all cases has been passed')
 
     # await tgc.reconnect()
     # await tgc.stop()

--- a/tgcalls/src/FileAudioDevice.cpp
+++ b/tgcalls/src/FileAudioDevice.cpp
@@ -19,7 +19,7 @@ const size_t kPlayoutBufferSize =
 const size_t kRecordingBufferSize =
     kRecordingFixedSampleRate / 100 * kRecordingNumChannels * 2;
 
-FileAudioDevice::FileAudioDevice(FileAudioDeviceDescriptor *fileAudioDeviceDescriptor)
+FileAudioDevice::FileAudioDevice(std::shared_ptr<FileAudioDeviceDescriptor> fileAudioDeviceDescriptor)
     : _ptrAudioBuffer(nullptr),
       _recordingBuffer(nullptr),
       _playoutBuffer(nullptr),
@@ -32,7 +32,7 @@ FileAudioDevice::FileAudioDevice(FileAudioDeviceDescriptor *fileAudioDeviceDescr
       _recording(false),
       _lastCallPlayoutMillis(0),
       _lastCallRecordMillis(0),
-      _fileAudioDeviceDescriptor(fileAudioDeviceDescriptor) {}
+      _fileAudioDeviceDescriptor(std::move(fileAudioDeviceDescriptor)) {}
 
 FileAudioDevice::~FileAudioDevice() = default;
 

--- a/tgcalls/src/FileAudioDevice.h
+++ b/tgcalls/src/FileAudioDevice.h
@@ -36,7 +36,7 @@ public:
   // The input file should be a readable 48k stereo raw file, and the output
   // file should point to a writable location. The output format will also be
   // 48k stereo raw audio.
-  explicit FileAudioDevice(FileAudioDeviceDescriptor*);
+  explicit FileAudioDevice(std::shared_ptr<FileAudioDeviceDescriptor>);
 
   ~FileAudioDevice() override;
 
@@ -198,5 +198,5 @@ private:
   webrtc::FileWrapper _outputFile;
   webrtc::FileWrapper _inputFile;
 
-  FileAudioDeviceDescriptor *_fileAudioDeviceDescriptor;
+  std::shared_ptr<FileAudioDeviceDescriptor> _fileAudioDeviceDescriptor;
 };

--- a/tgcalls/src/NativeInstance.h
+++ b/tgcalls/src/NativeInstance.h
@@ -26,7 +26,8 @@ public:
     std::function<void(tgcalls::GroupJoinPayload payload)> _emitJoinPayloadCallback = nullptr;
     std::function<void(bool)> _networkStateUpdated = nullptr;
 
-    rtc::scoped_refptr<webrtc::AudioDeviceModule> _audioDeviceModule;
+    std::shared_ptr<FileAudioDeviceDescriptor> _fileAudioDeviceDescriptor;
+    std::shared_ptr<RawAudioDeviceDescriptor> _rawAudioDeviceDescriptor;
 
     NativeInstance(bool, string);
     ~NativeInstance();
@@ -39,8 +40,8 @@ public:
             int
     );
 
-    void startGroupCall(FileAudioDeviceDescriptor &);
-    void startGroupCall(RawAudioDeviceDescriptor &);
+    void startGroupCall(std::shared_ptr<FileAudioDeviceDescriptor>);
+    void startGroupCall(std::shared_ptr<RawAudioDeviceDescriptor>);
     void startGroupCall(std::string, std::string);
     void stopGroupCall() const;
     bool isGroupCallStarted() const;
@@ -52,6 +53,9 @@ public:
 
     void restartAudioInputDevice() const;
     void restartAudioOutputDevice() const;
+
+    void stopAudioDeviceModule() const;
+    void startAudioDeviceModule() const;
 
     void printAvailablePlayoutDevices() const;
     void printAvailableRecordingDevices() const;

--- a/tgcalls/src/RawAudioDevice.cpp
+++ b/tgcalls/src/RawAudioDevice.cpp
@@ -20,7 +20,7 @@ const size_t kPlayoutBufferSize =
 const size_t kRecordingBufferSize =
     kRecordingFixedSampleRate / 100 * kRecordingNumChannels * 2;
 
-RawAudioDevice::RawAudioDevice(RawAudioDeviceDescriptor *RawAudioDeviceDescriptor)
+RawAudioDevice::RawAudioDevice(std::shared_ptr<RawAudioDeviceDescriptor> RawAudioDeviceDescriptor)
     : _ptrAudioBuffer(nullptr),
       _recordingBuffer(nullptr),
       _playoutBuffer(nullptr),
@@ -32,7 +32,7 @@ RawAudioDevice::RawAudioDevice(RawAudioDeviceDescriptor *RawAudioDeviceDescripto
       _recording(false),
       _lastCallPlayoutMillis(0),
       _lastCallRecordMillis(0),
-      _rawAudioDeviceDescriptor(RawAudioDeviceDescriptor) {}
+      _rawAudioDeviceDescriptor(std::move(RawAudioDeviceDescriptor)) {}
 
 RawAudioDevice::~RawAudioDevice() = default;
 
@@ -447,6 +447,7 @@ bool RawAudioDevice::RecThreadProcess() {
     if (!_rawAudioDeviceDescriptor->_isPlayoutPaused()) {
       _recordingBuffer = _rawAudioDeviceDescriptor->_getPlayoutBuffer(kRecordingBufferSize);
       _ptrAudioBuffer->SetRecordedBuffer(_recordingBuffer, _recordingFramesIn10MS);
+      free(_recordingBuffer);
 
       _lastCallRecordMillis = currentTime;
       mutex_.Unlock();

--- a/tgcalls/src/RawAudioDevice.h
+++ b/tgcalls/src/RawAudioDevice.h
@@ -17,7 +17,7 @@ namespace rtc {
 
 class RawAudioDevice : public webrtc::AudioDeviceGeneric {
 public:
-  explicit RawAudioDevice(RawAudioDeviceDescriptor*);
+  explicit RawAudioDevice(std::shared_ptr<RawAudioDeviceDescriptor>);
 
   ~RawAudioDevice() override;
 
@@ -159,5 +159,5 @@ private:
   int64_t _lastCallPlayoutMillis;
   int64_t _lastCallRecordMillis;
 
-  RawAudioDeviceDescriptor *_rawAudioDeviceDescriptor;
+  std::shared_ptr<RawAudioDeviceDescriptor> _rawAudioDeviceDescriptor;
 };

--- a/tgcalls/src/RawAudioDeviceDescriptor.cpp
+++ b/tgcalls/src/RawAudioDeviceDescriptor.cpp
@@ -1,12 +1,12 @@
 #include "RawAudioDeviceDescriptor.h"
 
 void RawAudioDeviceDescriptor::_setRecordedBuffer(int8_t *frame, size_t length) const {
-  _setRecordedBufferCallback(std::string ((const char *) frame, sizeof(int8_t) * length), length);
+  auto bytes = std::string((const char *) frame, sizeof(int8_t) * length);
+  _setRecordedBufferCallback(bytes, length);
 }
 
 int8_t *RawAudioDeviceDescriptor::_getPlayoutBuffer(size_t length) const {
   std::string frame = _getPlayedBufferCallback(length);
 
-  // TODO
-  return (int8_t *) frame.data();
+  return (int8_t *) (new std::string{frame})->data();
 }

--- a/tgcalls/src/WrappedAudioDeviceModuleImpl.cpp
+++ b/tgcalls/src/WrappedAudioDeviceModuleImpl.cpp
@@ -3,25 +3,25 @@
 rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl>
 WrappedAudioDeviceModuleImpl::Create(
     AudioLayer audio_layer, webrtc::TaskQueueFactory *task_queue_factory,
-    FileAudioDeviceDescriptor *fileAudioDeviceDescriptor) {
+    std::shared_ptr<FileAudioDeviceDescriptor> fileAudioDeviceDescriptor) {
   RTC_LOG(INFO) << __FUNCTION__;
   return WrappedAudioDeviceModuleImpl::CreateForTest(
-      audio_layer, task_queue_factory, fileAudioDeviceDescriptor);
+      audio_layer, task_queue_factory, std::move(fileAudioDeviceDescriptor));
 }
 
 rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl>
 WrappedAudioDeviceModuleImpl::Create(
     AudioLayer audio_layer, webrtc::TaskQueueFactory *task_queue_factory,
-    RawAudioDeviceDescriptor *rawAudioDeviceDescriptor) {
+    std::shared_ptr<RawAudioDeviceDescriptor> rawAudioDeviceDescriptor) {
   RTC_LOG(INFO) << __FUNCTION__;
   return WrappedAudioDeviceModuleImpl::CreateForTest(
-      audio_layer, task_queue_factory, rawAudioDeviceDescriptor);
+      audio_layer, task_queue_factory, std::move(rawAudioDeviceDescriptor));
 }
 
 rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl>
 WrappedAudioDeviceModuleImpl::CreateForTest(
     AudioLayer audio_layer, webrtc::TaskQueueFactory *task_queue_factory,
-    FileAudioDeviceDescriptor *fileAudioDeviceDescriptor) {
+    std::shared_ptr<FileAudioDeviceDescriptor> fileAudioDeviceDescriptor) {
   RTC_LOG(INFO) << __FUNCTION__;
 
   // Create the generic reference counted (platform independent) implementation.
@@ -34,7 +34,7 @@ WrappedAudioDeviceModuleImpl::CreateForTest(
     return nullptr;
   }
 
-  audioDevice->ResetAudioDevice(new FileAudioDevice(fileAudioDeviceDescriptor));
+  audioDevice->ResetAudioDevice(new FileAudioDevice(std::move(fileAudioDeviceDescriptor)));
 
   // Ensure that the generic audio buffer can communicate with the platform
   // specific parts.
@@ -48,7 +48,7 @@ WrappedAudioDeviceModuleImpl::CreateForTest(
 rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl>
 WrappedAudioDeviceModuleImpl::CreateForTest(
     AudioLayer audio_layer, webrtc::TaskQueueFactory *task_queue_factory,
-    RawAudioDeviceDescriptor *rawAudioDeviceDescriptor) {
+    std::shared_ptr<RawAudioDeviceDescriptor> rawAudioDeviceDescriptor) {
   RTC_LOG(INFO) << __FUNCTION__;
 
   // Create the generic reference counted (platform independent) implementation.
@@ -61,7 +61,7 @@ WrappedAudioDeviceModuleImpl::CreateForTest(
     return nullptr;
   }
 
-  audioDevice->ResetAudioDevice(new RawAudioDevice(rawAudioDeviceDescriptor));
+  audioDevice->ResetAudioDevice(new RawAudioDevice(std::move(rawAudioDeviceDescriptor)));
 
   // Ensure that the generic audio buffer can communicate with the platform
   // specific parts.

--- a/tgcalls/src/WrappedAudioDeviceModuleImpl.h
+++ b/tgcalls/src/WrappedAudioDeviceModuleImpl.h
@@ -18,20 +18,20 @@ public:
   static rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl> Create(
       AudioLayer,
       webrtc::TaskQueueFactory *,
-      FileAudioDeviceDescriptor *);
+      std::shared_ptr<FileAudioDeviceDescriptor>);
 
   static rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl> Create(
       AudioLayer,
       webrtc::TaskQueueFactory *,
-      RawAudioDeviceDescriptor *);
+      std::shared_ptr<RawAudioDeviceDescriptor>);
 
   static rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl> CreateForTest(
       AudioLayer,
       webrtc::TaskQueueFactory *,
-      FileAudioDeviceDescriptor *);
+      std::shared_ptr<FileAudioDeviceDescriptor>);
 
   static rtc::scoped_refptr<webrtc::AudioDeviceModuleImpl> CreateForTest(
       AudioLayer,
       webrtc::TaskQueueFactory *,
-      RawAudioDeviceDescriptor *);
+      std::shared_ptr<RawAudioDeviceDescriptor>);
 };

--- a/tgcalls/src/tgcalls.cpp
+++ b/tgcalls/src/tgcalls.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include <sstream>
 
-#include <pybind11/pybind11.h>
+#include <pybind11/smart_holder.h>
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
 
@@ -13,6 +13,13 @@ void ping() {
     py::print("pong");
 }
 
+PYBIND11_TYPE_CASTER_BASE_HOLDER(T, std::unique_ptr<T>)
+
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(FileAudioDeviceDescriptor)
+PYBIND11_SMART_HOLDER_TYPE_CASTERS(RawAudioDeviceDescriptor)
+
+PYBIND11_TYPE_CASTER_BASE_HOLDER(FileAudioDeviceDescriptor, std::shared_ptr<FileAudioDeviceDescriptor)
+PYBIND11_TYPE_CASTER_BASE_HOLDER(RawAudioDeviceDescriptor, std::shared_ptr<RawAudioDeviceDescriptor>)
 PYBIND11_MODULE(tgcalls, m) {
     m.def("ping", &ping);
 
@@ -74,7 +81,7 @@ PYBIND11_MODULE(tgcalls, m) {
             .def_readwrite("ssrcs", &tgcalls::GroupJoinPayloadVideoSourceGroup::ssrcs)
             .def_readwrite("semantics", &tgcalls::GroupJoinPayloadVideoSourceGroup::semantics);
 
-    py::class_<FileAudioDeviceDescriptor>(m, "FileAudioDeviceDescriptor")
+    py::classh<FileAudioDeviceDescriptor>(m, "FileAudioDeviceDescriptor")
             .def(py::init<>())
             .def_readwrite("getInputFilename", &FileAudioDeviceDescriptor::_getInputFilename)
             .def_readwrite("getOutputFilename", &FileAudioDeviceDescriptor::_getOutputFilename)
@@ -83,7 +90,7 @@ PYBIND11_MODULE(tgcalls, m) {
             .def_readwrite("isRecordingPaused", &FileAudioDeviceDescriptor::_isRecordingPaused)
             .def_readwrite("playoutEndedCallback", &FileAudioDeviceDescriptor::_playoutEndedCallback);
 
-    py::class_<RawAudioDeviceDescriptor>(m, "RawAudioDeviceDescriptor")
+    py::classh<RawAudioDeviceDescriptor>(m, "RawAudioDeviceDescriptor")
             .def(py::init<>())
             .def_readwrite("setRecordedBufferCallback", &RawAudioDeviceDescriptor::_setRecordedBufferCallback)
             .def_readwrite("getPlayedBufferCallback", &RawAudioDeviceDescriptor::_getPlayedBufferCallback)
@@ -100,8 +107,8 @@ PYBIND11_MODULE(tgcalls, m) {
             .def(py::init<bool, string>())
             .def("startCall", &NativeInstance::startCall)
             .def("setupGroupCall", &NativeInstance::setupGroupCall)
-            .def("startGroupCall", py::overload_cast<FileAudioDeviceDescriptor &>(&NativeInstance::startGroupCall))
-            .def("startGroupCall", py::overload_cast<RawAudioDeviceDescriptor &>(&NativeInstance::startGroupCall))
+            .def("startGroupCall", py::overload_cast<std::shared_ptr<FileAudioDeviceDescriptor>>(&NativeInstance::startGroupCall))
+            .def("startGroupCall", py::overload_cast<std::shared_ptr<RawAudioDeviceDescriptor>>(&NativeInstance::startGroupCall))
             .def("startGroupCall", py::overload_cast<std::string, std::string>(&NativeInstance::startGroupCall))
             .def("isGroupCallStarted", &NativeInstance::isGroupCallStarted)
             .def("stopGroupCall", &NativeInstance::stopGroupCall)
@@ -109,6 +116,8 @@ PYBIND11_MODULE(tgcalls, m) {
             .def("setVolume", &NativeInstance::setVolume)
             .def("restartAudioInputDevice", &NativeInstance::restartAudioInputDevice)
             .def("restartAudioOutputDevice", &NativeInstance::restartAudioOutputDevice)
+            .def("stopAudioDeviceModule", &NativeInstance::stopAudioDeviceModule)
+            .def("startAudioDeviceModule", &NativeInstance::startAudioDeviceModule)
             .def("printAvailablePlayoutDevices", &NativeInstance::printAvailablePlayoutDevices)
             .def("printAvailableRecordingDevices", &NativeInstance::printAvailableRecordingDevices)
             .def("setAudioOutputDevice", &NativeInstance::setAudioOutputDevice)

--- a/tgcalls/third_party/lib_tgcalls/tgcalls/group/GroupInstanceCustomImpl.h
+++ b/tgcalls/third_party/lib_tgcalls/tgcalls/group/GroupInstanceCustomImpl.h
@@ -43,7 +43,12 @@ public:
     void setVolume(uint32_t ssrc, double volume);
     void setRequestedVideoChannels(std::vector<VideoChannelDescription> &&requestedVideoChannels);
 
-//private:
+    void stopAudioDeviceModule() const;
+    void startAudioDeviceModule() const;
+    void restartAudioInputDevice() const;
+    void restartAudioOutputDevice() const;
+
+  private:
     std::shared_ptr<Threads> _threads;
     std::unique_ptr<ThreadLocalObject<GroupInstanceCustomInternal>> _internal;
     std::unique_ptr<LogSinkImpl> _logSink;

--- a/tgcalls/third_party/lib_tgcalls/tgcalls/platform/darwin/AudioDeviceModuleIOS.h
+++ b/tgcalls/third_party/lib_tgcalls/tgcalls/platform/darwin/AudioDeviceModuleIOS.h
@@ -14,13 +14,14 @@ public:
     virtual ~AudioDeviceModuleIOS() {
     }
 
-    virtual int32_t StopPlayout() override {
-        return 0;
-    }
-
-    virtual int32_t StopRecording() override {
-        return 0;
-    }
+// отдохни
+//    virtual int32_t StopPlayout() override {
+//        return 0;
+//    }
+//
+//    virtual int32_t StopRecording() override {
+//        return 0;
+//    }
 
     virtual int32_t Terminate() override {
         return 0;


### PR DESCRIPTION
using smart-holder version of pybind11;
using smart pointers in main parts of binding;
fix calling of method for audio device model (now in the right thread);
move working with audio device module from binding to tgcalls because it should works from right threads (in prev version we cant destruct audio device module because it was create in thread of tgcalls);
add new native method to implement right flow with stopping and destroying instances (stopAudioDeviceModule, startAudioDeviceModule);
fix audio device wrapper for macOS;
fix malloc for raw group call;
rework waiting from sleeps to asyncio events.