### PR TITLE
2.0.0 dev 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(tgcalls
     LANGUAGES C CXX
     DESCRIPTION "Python binding for tgcalls"
     HOMEPAGE_URL "https://github.com/MarshalX/tgcalls"
-    VERSION "2.0.0.2"
+    VERSION "2.0.0.3"
 )
 
 get_filename_component(third_party_loc "tgcalls/third_party" REALPATH)

--- a/build/ubuntu/Dockerfile
+++ b/build/ubuntu/Dockerfile
@@ -206,6 +206,18 @@ RUN cmake -B out/Release . \
     -DTG_OWT_FFMPEG_INCLUDE_PATH=/usr/local/include
 RUN cmake --build out/Release -- -j$(nproc)
 
+RUN cmake -B out/Debug . \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DTG_OWT_SPECIAL_TARGET=linux \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DTG_OWT_USE_PIPEWIRE=OFF \
+    -DTG_OWT_LIBJPEG_INCLUDE_PATH=/usr/local/include \
+    -DTG_OWT_OPENSSL_INCLUDE_PATH=$OPENSSL_PREFIX/include \
+    -DTG_OWT_OPUS_INCLUDE_PATH=/usr/local/include/opus \
+    -DTG_OWT_FFMPEG_INCLUDE_PATH=/usr/local/include
+RUN cmake --build out/Debug -- -j$(nproc)
+
 WORKDIR ..
 
 FROM builder
@@ -220,5 +232,8 @@ COPY --from=webrtc ${LibrariesPath}/webrtc tg_owt
 WORKDIR ..
 COPY ./ ${MainPath}/tgcalls
 WORKDIR ${MainPath}/tgcalls
+
+RUN pip3 install pyrogram tgcrypto telethon
+RUN python3 setup.py build --debug
 
 CMD pip3 wheel . --no-deps -w ../dist/ --use-feature=in-tree-build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
     build:
       context: .
       dockerfile: build/ubuntu/Dockerfile
-    command: pip3 wheel . --no-deps -w ../dist/ --use-feature=in-tree-build
+    env_file: pytgcalls/.env
+#    command: tail -F anything
+    command: python3 pytgcalls/test3.py
     volumes:
       - ./dist:/usr/src/dist
+      - ./pytgcalls:/usr/src/tgcalls/pytgcalls

--- a/examples/device_playout.py
+++ b/examples/device_playout.py
@@ -31,8 +31,8 @@ async def main(client):
     await group_call.start(CHAT_ID)
 
     # to get available device names
-    group_call.print_available_playout_devices()
-    group_call.print_available_recording_devices()
+    print(group_call.get_playout_devices())
+    print(group_call.get_recording_devices())
 
     await pyrogram.idle()
 

--- a/pytgcalls/pytgcalls/__init__.py
+++ b/pytgcalls/pytgcalls/__init__.py
@@ -81,7 +81,7 @@ __all__ = [
     'GroupCallDevice',
     'GroupCallRaw',
 ]
-__version__ = '2.0.0.dev3'
+__version__ = '2.0.0.dev4'
 __pdoc__ = {
     # files
     'utils': False,

--- a/pytgcalls/pytgcalls/implementation/group_call_device.py
+++ b/pytgcalls/pytgcalls/implementation/group_call_device.py
@@ -48,7 +48,7 @@ class GroupCallDevice(GroupCallNative):
         """Get audio input device name or GUID
 
         Note:
-            To get system recording device list you can use `print_available_recording_devices()` method.
+            To get system recording device list you can use `get_recording_devices()` method.
         """
 
         return self.__audio_input_device
@@ -62,7 +62,7 @@ class GroupCallDevice(GroupCallNative):
         """Get audio output device name or GUID
 
         Note:
-            To get system playout device list you can use `print_available_playout_devices()` method.
+            To get system playout device list you can use `get_playout_devices()` method.
         """
 
         return self.__audio_output_device

--- a/pytgcalls/setup.py
+++ b/pytgcalls/setup.py
@@ -44,7 +44,7 @@ setup(
     long_description=readme,
     long_description_content_type='text/markdown',
     packages=packages,
-    install_requires=['tgcalls == 2.0.0.dev2'],
+    install_requires=['tgcalls == 2.0.0.dev3'],
     extras_require={
         'pyrogram': ['pyrogram >= 1.2.0'],
         'telethon': ['telethon >= 1.23.0'],

--- a/pytgcalls/test.py
+++ b/pytgcalls/test.py
@@ -457,7 +457,7 @@ async def start(client1, client2, make_out, make_inc):
 
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 for name, logger in logging.root.manager.loggerDict.items():
     if name.startswith('pyrogram'):
@@ -499,8 +499,8 @@ async def main(client1, client2, telethon1, make_out, make_inc):
     # except RuntimeError:
     #     print('pass2')
 
-    # group_call = group_call_factory.get_device_group_call()
-    group_call = group_call_factory.get_file_group_call('input.raw')
+    group_call = group_call_factory.get_device_group_call()
+    # group_call = group_call_factory.get_file_group_call('input.raw')
     # group_call = group_call_factory.get_raw_group_call(on_recorded_data=on_recorded_data, on_played_data=on_played_data)
     await group_call.start('@ilya_marshal')
     # await asyncio.sleep(15)
@@ -509,6 +509,11 @@ async def main(client1, client2, telethon1, make_out, make_inc):
     # await group_call.reconnect()
     # await group_call.start('@ilya_marshal')
     # await asyncio.sleep(2)
+    print(group_call.get_playout_devices())
+    print(group_call.get_recording_devices())
+    group_call.print_available_playout_devices()
+    group_call.print_available_recording_devices()
+    await asyncio.sleep(2)
 
     # while True:
     #     group_call_factory = GroupCallFactory(telethon1, GroupCallFactory.MTPROTO_CLIENT_TYPE.TELETHON)

--- a/tgcalls/src/NativeInstance.h
+++ b/tgcalls/src/NativeInstance.h
@@ -44,7 +44,7 @@ public:
     void startGroupCall(std::shared_ptr<RawAudioDeviceDescriptor>);
     void startGroupCall(std::string, std::string);
     void stopGroupCall() const;
-    bool isGroupCallStarted() const;
+    bool isGroupCallNativeCreated() const;
 
     void setIsMuted(bool isMuted) const;
     void setVolume(uint32_t ssrc, double volume) const;
@@ -57,8 +57,9 @@ public:
     void stopAudioDeviceModule() const;
     void startAudioDeviceModule() const;
 
-    void printAvailablePlayoutDevices() const;
-    void printAvailableRecordingDevices() const;
+    std::vector<tgcalls::GroupInstanceInterface::AudioDevice> getPlayoutDevices() const;
+    std::vector<tgcalls::GroupInstanceInterface::AudioDevice> getRecordingDevices() const;
+
     void setAudioOutputDevice(std::string id) const;
     void setAudioInputDevice(std::string id) const;
 

--- a/tgcalls/src/RawAudioDevice.cpp
+++ b/tgcalls/src/RawAudioDevice.cpp
@@ -445,14 +445,16 @@ bool RawAudioDevice::RecThreadProcess() {
 
   if (_lastCallRecordMillis == 0 || currentTime - _lastCallRecordMillis >= 10) {
     if (!_rawAudioDeviceDescriptor->_isPlayoutPaused()) {
-      _recordingBuffer = _rawAudioDeviceDescriptor->_getPlayoutBuffer(kRecordingBufferSize);
-      _ptrAudioBuffer->SetRecordedBuffer(_recordingBuffer, _recordingFramesIn10MS);
-      free(_recordingBuffer);
+      auto recordingStringBuffer = _rawAudioDeviceDescriptor->_getPlayoutBuffer(kRecordingBufferSize);
+//      in prev impl was setting of _recordingBuffer
+      _ptrAudioBuffer->SetRecordedBuffer((int8_t *) recordingStringBuffer->data(), _recordingFramesIn10MS);
 
       _lastCallRecordMillis = currentTime;
       mutex_.Unlock();
       _ptrAudioBuffer->DeliverRecordedData();
       mutex_.Lock();
+
+      delete recordingStringBuffer;
     }
   }
 

--- a/tgcalls/src/RawAudioDeviceDescriptor.cpp
+++ b/tgcalls/src/RawAudioDeviceDescriptor.cpp
@@ -5,8 +5,8 @@ void RawAudioDeviceDescriptor::_setRecordedBuffer(int8_t *frame, size_t length) 
   _setRecordedBufferCallback(bytes, length);
 }
 
-int8_t *RawAudioDeviceDescriptor::_getPlayoutBuffer(size_t length) const {
+std::string *RawAudioDeviceDescriptor::_getPlayoutBuffer(size_t length) const {
   std::string frame = _getPlayedBufferCallback(length);
 
-  return (int8_t *) (new std::string{frame})->data();
+  return new std::string{frame};
 }

--- a/tgcalls/src/RawAudioDeviceDescriptor.h
+++ b/tgcalls/src/RawAudioDeviceDescriptor.h
@@ -16,5 +16,5 @@ public:
     std::function<bool()> _isRecordingPaused = nullptr;
 
     void _setRecordedBuffer(int8_t*, size_t) const;
-    int8_t* _getPlayoutBuffer(size_t) const;
+    std::string* _getPlayoutBuffer(size_t) const;
 };

--- a/tgcalls/src/tgcalls.cpp
+++ b/tgcalls/src/tgcalls.cpp
@@ -97,6 +97,17 @@ PYBIND11_MODULE(tgcalls, m) {
             .def_readwrite("isPlayoutPaused", &RawAudioDeviceDescriptor::_isPlayoutPaused)
             .def_readwrite("isRecordingPaused", &RawAudioDeviceDescriptor::_isRecordingPaused);
 
+    py::class_<tgcalls::GroupInstanceInterface::AudioDevice>(m, "AudioDevice")
+            .def_readwrite("name", &tgcalls::GroupInstanceInterface::AudioDevice::name)
+            .def_readwrite("guid", &tgcalls::GroupInstanceInterface::AudioDevice::guid)
+            .def("__repr__", [](const tgcalls::GroupInstanceInterface::AudioDevice &e) {
+              ostringstream repr;
+              repr << "<tgcalls.AudioDevice ";
+              repr << "name=\"" << e.name << "\" ";
+              repr << "guid=\"" << e.guid << "\"> ";
+              return repr.str();
+            });
+
     py::enum_<tgcalls::GroupConnectionMode>(m, "GroupConnectionMode")
             .value("GroupConnectionModeNone", tgcalls::GroupConnectionMode::GroupConnectionModeNone)
             .value("GroupConnectionModeRtc", tgcalls::GroupConnectionMode::GroupConnectionModeRtc)
@@ -110,7 +121,7 @@ PYBIND11_MODULE(tgcalls, m) {
             .def("startGroupCall", py::overload_cast<std::shared_ptr<FileAudioDeviceDescriptor>>(&NativeInstance::startGroupCall))
             .def("startGroupCall", py::overload_cast<std::shared_ptr<RawAudioDeviceDescriptor>>(&NativeInstance::startGroupCall))
             .def("startGroupCall", py::overload_cast<std::string, std::string>(&NativeInstance::startGroupCall))
-            .def("isGroupCallStarted", &NativeInstance::isGroupCallStarted)
+            .def("isGroupCallNativeCreated", &NativeInstance::isGroupCallNativeCreated)
             .def("stopGroupCall", &NativeInstance::stopGroupCall)
             .def("setIsMuted", &NativeInstance::setIsMuted)
             .def("setVolume", &NativeInstance::setVolume)
@@ -118,8 +129,8 @@ PYBIND11_MODULE(tgcalls, m) {
             .def("restartAudioOutputDevice", &NativeInstance::restartAudioOutputDevice)
             .def("stopAudioDeviceModule", &NativeInstance::stopAudioDeviceModule)
             .def("startAudioDeviceModule", &NativeInstance::startAudioDeviceModule)
-            .def("printAvailablePlayoutDevices", &NativeInstance::printAvailablePlayoutDevices)
-            .def("printAvailableRecordingDevices", &NativeInstance::printAvailableRecordingDevices)
+            .def("getPlayoutDevices", &NativeInstance::getPlayoutDevices)
+            .def("getRecordingDevices", &NativeInstance::getRecordingDevices)
             .def("setAudioOutputDevice", &NativeInstance::setAudioOutputDevice)
             .def("setAudioInputDevice", &NativeInstance::setAudioInputDevice)
             .def("setJoinResponsePayload", &NativeInstance::setJoinResponsePayload)

--- a/tgcalls/third_party/lib_tgcalls/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.cpp
+++ b/tgcalls/third_party/lib_tgcalls/tgcalls/desktop_capturer/DesktopCaptureSourceHelper.cpp
@@ -286,8 +286,8 @@ DesktopSourceRenderer::DesktopSourceRenderer(
     options.set_allow_use_magnification_api(false);
 #elif defined WEBRTC_MAC
     options.set_allow_iosurface(true);
-#elif defined WEBRTC_LINUX // its not enough statement cuz we can build tg_owg without pipewire
-//    options.set_allow_pipewire(true);
+#elif defined WEBRTC_USE_PIPEWIRE
+    options.set_allow_pipewire(true);
 #endif // WEBRTC_WIN || WEBRTC_MAC
 
     if (source.isWindow()) {

--- a/tgcalls/third_party/lib_tgcalls/tgcalls/desktop_capturer/DesktopCaptureSourceManager.cpp
+++ b/tgcalls/third_party/lib_tgcalls/tgcalls/desktop_capturer/DesktopCaptureSourceManager.cpp
@@ -33,8 +33,8 @@ webrtc::DesktopCaptureOptions DesktopCaptureSourceManager::OptionsForType(
     result.set_allow_use_magnification_api(false);
 #elif defined WEBRTC_MAC
     result.set_allow_iosurface(type == DesktopCaptureType::Screen);
-#elif defined WEBRTC_LINUX // its not enough statement cuz we can build tg_owg without pipewire
-//    result.set_allow_pipewire(true);
+#elif defined WEBRTC_USE_PIPEWIRE
+    result.set_allow_pipewire(true);
 #endif // WEBRTC_WIN || WEBRTC_MAC
     result.set_detect_updated_region(true);
     return result;

--- a/tgcalls/third_party/lib_tgcalls/tgcalls/group/GroupInstanceCustomImpl.h
+++ b/tgcalls/third_party/lib_tgcalls/tgcalls/group/GroupInstanceCustomImpl.h
@@ -9,6 +9,7 @@
 
 #include "../Instance.h"
 #include "GroupInstanceImpl.h"
+#include "../platform/PlatformInterface.h"
 
 namespace tgcalls {
 
@@ -43,10 +44,7 @@ public:
     void setVolume(uint32_t ssrc, double volume);
     void setRequestedVideoChannels(std::vector<VideoChannelDescription> &&requestedVideoChannels);
 
-    void stopAudioDeviceModule() const;
-    void startAudioDeviceModule() const;
-    void restartAudioInputDevice() const;
-    void restartAudioOutputDevice() const;
+    void performWithAudioDeviceModule(std::function<void(rtc::scoped_refptr<WrappedAudioDeviceModule>)> callback);
 
   private:
     std::shared_ptr<Threads> _threads;

--- a/tgcalls/third_party/webrtc/CMakeLists.txt
+++ b/tgcalls/third_party/webrtc/CMakeLists.txt
@@ -1947,13 +1947,14 @@ PRIVATE
     sdk/media_constraints.cc
 
     # screen drawer
-    modules/desktop_capture/screen_drawer.cc
-    modules/desktop_capture/screen_drawer.h
-    modules/desktop_capture/screen_drawer_mac.cc
-    modules/desktop_capture/screen_drawer_linux.cc
-    modules/desktop_capture/screen_drawer_lock_posix.cc
-    modules/desktop_capture/screen_drawer_lock_posix.h
-    modules/desktop_capture/screen_drawer_win.cc
+    # there is x11 required also
+#    modules/desktop_capture/screen_drawer.cc
+#    modules/desktop_capture/screen_drawer.h
+#    modules/desktop_capture/screen_drawer_mac.cc
+#    modules/desktop_capture/screen_drawer_linux.cc
+#    modules/desktop_capture/screen_drawer_lock_posix.cc
+#    modules/desktop_capture/screen_drawer_lock_posix.h
+#    modules/desktop_capture/screen_drawer_win.cc
 
     # primitives
     modules/desktop_capture/desktop_capture_types.h


### PR DESCRIPTION
fix issue with memory de-allocation in group call raw;
apply fix of building without pipewire from tg devs;
restore ability to get audio devices;
add ability to get list of audio devices instead of print;
rename isGroupCallStarted to isGroupCallNativeCreated;
make methods with printing audio devices deprecated;
move code that works with audio device model from tgcalls to binding (its possible via performWithAudioDeviceModule tgcalls method).

